### PR TITLE
[IMP] multiple functions were added to ```Quasigroup```

### DIFF
--- a/src/Quasigroup.ts
+++ b/src/Quasigroup.ts
@@ -76,20 +76,26 @@ export interface Quasigroup<A> extends Magma<A> {
 // -------------------------------------------------------------------------------------
 
 /**
- * The dual of a `Magma`, obtained by swapping the arguments of `concat`.
+ * The dual of a `Quasigroup`, obtained by swapping the arguments of the binary operations.
  *
  * @example
- * import { reverse, concatAll } from 'fp-ts/Magma'
+ * import { reverse, concatAll, leftInvAll, rightInvAll } from 'fp-ts/Quasigroup'
  * import * as N from 'fp-ts/number'
  *
- * const subAll = concatAll(reverse(N.MagmaSub))(0)
+ * const sumAll = concatAll(reverse(N.Quasigroup))(0)
+ * const subAll = leftInvAll(reverse(N.Quasigroup))(0)
+ * const diffAll = rightInvAll(reverse(N.Quasigroup))(0)
  *
- * assert.deepStrictEqual(subAll([1, 2, 3]), 2)
+ * assert.deepStrictEqual(sumAll([1, 2, 3]), 6)
+ * assert.deepStrictEqual(subAll([1, 2, 3]), -6)
+ * assert.deepStrictEqual(diffAll([1, 2, 3]), 2)
  *
  * @since 2.11.0
  */
-export const reverse = <A>(M: Magma<A>): Magma<A> => ({
-  concat: (first, second) => M.concat(second, first)
+export const reverse = <A>(Q: Quasigroup<A>): Quasigroup<A> => ({
+  concat: (first, second) => Q.concat(second, first),
+  leftInv: (first, second) => Q.rightInv(first, second),
+  rightInv: (first, second) => Q.leftInv(first, second)
 })
 
 /**
@@ -115,8 +121,10 @@ export const filterSecond =
  */
 export const endo =
   <A>(f: Endomorphism<A>) =>
-  (M: Magma<A>): Magma<A> => ({
-    concat: (first, second) => M.concat(f(first), f(second))
+  (Q: Quasigroup<A>): Quasigroup<A> => ({
+    concat: (first, second) => Q.concat(f(first), f(second)),
+    leftInv: (first, second) => Q.leftInv(f(first), f(second)),
+    rightInv: (first, second) => Q.rightInv(f(first), f(second))
   })
 
 // -------------------------------------------------------------------------------------
@@ -129,17 +137,59 @@ export const endo =
  * If `as` is empty, return the provided `startWith` value.
  *
  * @example
- * import { concatAll } from 'fp-ts/Magma'
+ * import { concatAll } from 'fp-ts/Quasigroup'
  * import * as N from 'fp-ts/number'
  *
- * const subAll = concatAll(N.MagmaSub)(0)
+ * const sumAll = concatAll(N.Quasigroup)(0)
+ *
+ * assert.deepStrictEqual(sumAll([1, 2, 3]), 6)
+ *
+ * @since 2.11.0
+ */
+export const concatAll =
+  <A>(Q: Quasigroup<A>) =>
+  (startWith: A) =>
+  (as: ReadonlyArray<A>): A =>
+    as.reduce((a, acc) => Q.concat(a, acc), startWith)
+
+/**
+ * Given a sequence of `as`, leftInv them and return the total.
+ *
+ * If `as` is empty, return the provided `startWith` value.
+ *
+ * @example
+ * import { leftInvAll } from 'fp-ts/Quasigroup'
+ * import * as N from 'fp-ts/number'
+ *
+ * const diffAll = leftInvAll(Q.Quasigroup)(0)
+ *
+ * assert.deepStrictEqual(diffAll([1, 2, 3, 4]), 2)
+ *
+ * @since 2.11.0
+ */
+export const leftInvAll =
+  <A>(Q: Quasigroup<A>) =>
+  (startWith: A) =>
+  (as: ReadonlyArray<A>): A =>
+    as.reduce((a, acc) => Q.leftInv(a, acc), startWith)
+    
+/**
+ * Given a sequence of `as`, rightInv them and return the total.
+ *
+ * If `as` is empty, return the provided `startWith` value.
+ *
+ * @example
+ * import { rightInv } from 'fp-ts/Quasigroup'
+ * import * as N from 'fp-ts/number'
+ *
+ * const subAll = rightInv(Q.Quasigroup)(0)
  *
  * assert.deepStrictEqual(subAll([1, 2, 3]), -6)
  *
  * @since 2.11.0
  */
-export const concatAll =
-  <A>(M: Magma<A>) =>
+export const rightInv =
+  <A>(Q: Quasigroup<A>) =>
   (startWith: A) =>
   (as: ReadonlyArray<A>): A =>
-    as.reduce((a, acc) => M.concat(a, acc), startWith)
+    as.reduce((a, acc) => Q.rightInv(a, acc), startWith)

--- a/src/number.ts
+++ b/src/number.ts
@@ -10,6 +10,7 @@ import * as O from './Ord'
 import { Refinement } from './Refinement'
 import { Semigroup } from './Semigroup'
 import * as S from './Show'
+import * as Q from './Quasigroup'
 
 // -------------------------------------------------------------------------------------
 // refinements
@@ -148,4 +149,14 @@ export const Field: F.Field<number> = {
   degree: (_) => 1,
   div: (first, second) => first / second,
   mod: (first, second) => first % second
+}
+
+/**
+ * @category instances
+ * @since 2.10.0
+ */
+export const Quasigroup: Q.Quasigroup<number> = {
+  concat: (first, second) => first + second,
+  leftInv: (first, second) => second - first,
+  rightInv: (first, second) => first - second
 }


### PR DESCRIPTION
```leftInvAll```, ```rightinvAll```, ```concatAll```, ```reverse```, ```endo``` were added to the ```Quasigroup``` interface. Also, ```Quasigroup``` function was added to ```number```.